### PR TITLE
Re-add line that was commented out

### DIFF
--- a/configs/config.txt
+++ b/configs/config.txt
@@ -61,5 +61,5 @@ dtparam=audio=on
 
 device_tree_address=0x02000000
 
-# dtoverlay=vc4-fkms-v3d,cma-256
+dtoverlay=vc4-fkms-v3d,cma-256
 dtoverlay=balena-fin


### PR DESCRIPTION
This concerns video capabilities (3d acceleration). This was removed during testing. I've tested with it reenabled and all is good